### PR TITLE
Add monitoring metrics

### DIFF
--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -202,7 +202,7 @@ async fn validate_tree_roots(rpc_client: &RpcClient, db_roots: Vec<(Pubkey, Hash
     } else {
         metric! {
             statsd_gauge!("root_validation_success", 1);
-            statsd_gauge!("root_validation_failures", 0);
+            statsd_count!("root_validation_failures", 0);
         }
     }
 }

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -176,6 +176,7 @@ async fn load_accounts_with_infinite_retry(
 }
 
 async fn validate_tree_roots(rpc_client: &RpcClient, db_roots: Vec<(Pubkey, Hash)>) {
+    let mut root_validation_errors = 0;
     for chunk in db_roots.chunks(CHUNK_SIZE) {
         let pubkeys = chunk.iter().map(|(pubkey, _)| pubkey.clone()).collect();
         let accounts = load_accounts_with_infinite_retry(rpc_client, pubkeys).await;
@@ -188,11 +189,19 @@ async fn validate_tree_roots(rpc_client: &RpcClient, db_roots: Vec<(Pubkey, Hash
                     db_hash,
                     account_roots
                 );
-                return;
+                root_validation_errors += 1;
             }
         }
     }
-    metric! {
-        statsd_count!("root_validation_success", 1);
+
+    if root_validation_errors > 0 {
+        metric! {
+            statsd_count!("root_validation_failures", root_validation_errors);
+            statsd_gauge!("root_validation_success", 0);
+        }
+    } else {
+        metric! {
+            statsd_gauge!("root_validation_success", 1);
+        }
     }
 }

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -190,6 +190,7 @@ async fn validate_tree_roots(rpc_client: &RpcClient, db_roots: Vec<(Pubkey, Hash
                     account_roots
                 );
                 root_validation_errors += 1;
+                statsd_count!("root_validation_failure", 1, "pubkey" => pubkey);
             }
         }
     }

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -202,6 +202,7 @@ async fn validate_tree_roots(rpc_client: &RpcClient, db_roots: Vec<(Pubkey, Hash
     } else {
         metric! {
             statsd_gauge!("root_validation_success", 1);
+            statsd_gauge!("root_validation_failures", 0);
         }
     }
 }


### PR DESCRIPTION
## Overview

- Track the number of root hash failures
- Turn success metric into a gauge
- Report 0/1 on the success metric

## Testing

-   cargo clippy only
