### PR TITLE
ci: migrate to goreleaser Gen 2 (PLA-455)

### DIFF
--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -1,0 +1,26 @@
+---
+name: GoReleaser config check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+  workflow_dispatch:
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: goreleaser check
+        run: goreleaser check

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,93 @@
+# .goreleaser.yaml for rpcpool/photon
+#
+# This file must be committed to the root of the photon source repo.
+# GCS upload, cosigning, and GitHub Release publishing are injected via
+# ci/goreleaser-patch.yaml in Binaries-ci at build time.
+#
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+builds:
+    - id: photon
+      builder: rust
+      binary: photon
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=photon
+
+    - id: photon-migration
+      builder: rust
+      binary: photon-migration
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=photon-migration
+
+    - id: photon-openapi
+      builder: rust
+      binary: photon-openapi
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=photon-openapi
+
+    - id: photon-snapshot-loader
+      builder: rust
+      binary: photon-snapshot-loader
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=photon-snapshot-loader
+
+    - id: photon-snapshotter
+      builder: rust
+      binary: photon-snapshotter
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=photon-snapshotter
+
+archives:
+    - id: photon
+      ids: [photon]
+      name_template: photon-linux-amd64
+      formats: [binary]
+
+    - id: photon-migration
+      ids: [photon-migration]
+      name_template: photon-migration-linux-amd64
+      formats: [binary]
+
+    - id: photon-openapi
+      ids: [photon-openapi]
+      name_template: photon-openapi-linux-amd64
+      formats: [binary]
+
+    - id: photon-snapshot-loader
+      ids: [photon-snapshot-loader]
+      name_template: photon-snapshot-loader-linux-amd64
+      formats: [binary]
+
+    - id: photon-snapshotter
+      ids: [photon-snapshotter]
+      name_template: photon-snapshotter-linux-amd64
+      formats: [binary]
+
+release:
+    github:
+        owner: rpcpool
+        name: photon
+    draft: true
+    header: |
+        rust {{ .Env.RUST_VERSION }}
+
+changelog:
+    sort: asc
+    use: github

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,10 @@ builds:
       flags:
           - --release
           - --bin=photon
+      env:
+          - OPENSSL_INCLUDE_DIR=/usr/include
+          - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+          - CFLAGS_x86_64_unknown_linux_gnu=-isystem /usr/include/x86_64-linux-gnu
 
     - id: photon-migration
       builder: rust
@@ -26,6 +30,10 @@ builds:
       flags:
           - --release
           - --bin=photon-migration
+      env:
+          - OPENSSL_INCLUDE_DIR=/usr/include
+          - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+          - CFLAGS_x86_64_unknown_linux_gnu=-isystem /usr/include/x86_64-linux-gnu
 
     - id: photon-openapi
       builder: rust
@@ -35,6 +43,10 @@ builds:
       flags:
           - --release
           - --bin=photon-openapi
+      env:
+          - OPENSSL_INCLUDE_DIR=/usr/include
+          - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+          - CFLAGS_x86_64_unknown_linux_gnu=-isystem /usr/include/x86_64-linux-gnu
 
     - id: photon-snapshot-loader
       builder: rust
@@ -44,6 +56,10 @@ builds:
       flags:
           - --release
           - --bin=photon-snapshot-loader
+      env:
+          - OPENSSL_INCLUDE_DIR=/usr/include
+          - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+          - CFLAGS_x86_64_unknown_linux_gnu=-isystem /usr/include/x86_64-linux-gnu
 
     - id: photon-snapshotter
       builder: rust
@@ -53,6 +69,10 @@ builds:
       flags:
           - --release
           - --bin=photon-snapshotter
+      env:
+          - OPENSSL_INCLUDE_DIR=/usr/include
+          - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+          - CFLAGS_x86_64_unknown_linux_gnu=-isystem /usr/include/x86_64-linux-gnu
 
 archives:
     - id: photon

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "rustc-dev", "clippy", "cargo"]


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yaml` with five build entries (`photon`, `photon-migration`, `photon-openapi`, `photon-snapshot-loader`, `photon-snapshotter`), each with explicit `--bin` flags targeting `x86_64-unknown-linux-gnu` only
- Add `goreleaser-config-check.yaml` workflow to validate the config on PRs using GitHub-hosted runners
- Drops the ubuntu-24.04 matrix from the Gen 1 workflow

## Notes

GCS upload, cosigning, and GitHub Release publishing are injected by `ci/goreleaser-patch.yaml` in Binaries-ci at build time. Artifacts will be uploaded to `nomad-triton-test/photon/v<semver>/` replacing the old `nomad-triton-test/photon-indexer/<branch>/` path.

Companion PRs:
- rpcpool/Binaries-ci: remove Gen 1 `solana_photon-build-release.yml` workflow
- rpcpool/terraform: update Nomad job artifact paths to new GCS layout

## Test plan

- [ ] goreleaser-config-check.yaml passes on this PR
- [ ] Trigger a manual build via `build-release.yml` in Binaries-ci and verify all five binaries appear at `nomad-triton-test/photon/v<semver>/`
- [ ] Deploy terraform changes after first Gen 2 build produces artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)